### PR TITLE
Adds tags to task schema

### DIFF
--- a/docs/neuvuequeue.yaml
+++ b/docs/neuvuequeue.yaml
@@ -183,6 +183,9 @@ components:
             - incomplete
         points:
           type: object
+        tags:
+          type: array
+          items: string
       required:
         - assignee
         - author
@@ -592,6 +595,48 @@ paths:
       responses:
         '200':
           description: The status has been changed. Returns the previous task object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+        '400':
+          description: Bad request. The ID is invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+/tasks/{taskId}/tags:
+    patch:
+      tags:
+        - Tasks
+      summary: Set the tags of a task
+      parameters:
+        - name: taskId
+          in: path
+          required: true
+          description: task ID.
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tags:
+                  type: array
+                  items: string
+      responses:
+        '200':
+          description: The tags have been changed. Returns the previous task object.
           content:
             application/json:
               schema:

--- a/src/models/task.ts
+++ b/src/models/task.ts
@@ -19,7 +19,8 @@ const schema = new Schema({
     },
     seg_id: {type: String, default: null},
     ng_state: {type: String, default: null},
-    points: {type: [Schema.Types.ObjectId], default: [], ref: "Point"}
+    points: {type: [Schema.Types.ObjectId], default: [], ref: "Point"},
+    tags: {type: [String], default: []}
 });
 
 const Task = model("Task", schema);


### PR DESCRIPTION
NB: Does NOT break old tasks - although already-assigned tasks will not properly use the feature. They shouldn't break if you try to give tags to an old task, but it will not save them.