### PR TITLE
Opened Time Fix

### DIFF
--- a/src/controllers/task.ts
+++ b/src/controllers/task.ts
@@ -27,7 +27,7 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
             if (update.status === "pending") {
                 update.closed = null;
                 update.opened = null;
-            } else if (update.status === "open") {
+            } else if (update.status === "open" && req.body.overwrite_opened) {
                 update.opened = Date.now();
             } else if (update.status === "closed" || update.status === "errored") {
                 update.closed = Date.now();

--- a/src/controllers/task.ts
+++ b/src/controllers/task.ts
@@ -26,7 +26,6 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
 
             if (update.status === "pending") {
                 update.closed = null;
-                update.opened = null;
             } else if (update.status === "open" && req.body.overwrite_opened) {
                 update.opened = Date.now();
             } else if (update.status === "closed" || update.status === "errored") {


### PR DESCRIPTION
The $min operator doesn't replace null values for unopened tasks so I couldn't use that one. In this case I look for an additional parameter in the request to see if I should overwrite, so the logic is actually managed by the client now. 