### PR TITLE
add readScopes to points, tasks and differ_stacks

### DIFF
--- a/src/controllers/differ_stack.ts
+++ b/src/controllers/differ_stack.ts
@@ -26,7 +26,7 @@ export default class DifferStackController extends mix(Controller).with(CRUDMixi
         const readScopes = 'read:tasks';
         const writeScopes = 'update:tasks';
 
-        server.get(root, this.query(_.get("query", options)));
+        server.get(root, auth0(true, readScopes), this.query(_.get("query", options)));
         server.get(`${root}/:id`, this.detail(_.get("detail", options)));
         server.post(root, auth0(true, writeScopes), this.insert());
         server.del(`${root}/:id`, auth0(true, writeScopes), this.deactivate());

--- a/src/controllers/point.ts
+++ b/src/controllers/point.ts
@@ -24,9 +24,11 @@ export default class PointController extends mix(Controller).with(CRUDMixin, Dec
         if (root.endsWith("/")) {
             root = root.substring(0, root.length - 1);
         }
+
+        const readScopes = 'read:points';
         const writeScopes = 'update:points';
 
-        server.get(root, this.query(_.get("query", options)));
+        server.get(root, auth0(true, readScopes), this.query(_.get("query", options)));
         server.get(`${root}/:id`, this.detail(_.get("detail", options)));
         server.post(root, auth0(true, writeScopes), this.insert());
         server.del(`${root}/:id`, this.deactivate());

--- a/src/controllers/task.ts
+++ b/src/controllers/task.ts
@@ -335,7 +335,7 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
         const readScopes = 'read:tasks';
         const writeScopes = 'update:tasks';
 
-        server.get(root, this.query(_.get("query", options)));
+        server.get(root, auth0(true, readScopes), this.query(_.get("query", options)));
         server.get(`${root}/:id`, this.detail(_.get("detail", options)));
         server.post(root, auth0(true, writeScopes), this.insert());
         server.del(`${root}/:id`, auth0(true, writeScopes),this.deactivate());


### PR DESCRIPTION
updates the following schemas to require readScopes (auth0):
- points
- tasks
- differ_stack