### PR TITLE
Namespace write guard

### DIFF
--- a/src/controllers/mixins.ts
+++ b/src/controllers/mixins.ts
@@ -230,7 +230,6 @@ export const CRUDMixin = (superclass: any) => class extends superclass {
 export const DecidableMixin = (superclass: any) => class extends superclass {
     protected model: Model<Document>;
 
-    // TODO
     public appendDecision(): (req: Request, res: Response, next: Next) => void {
         return (req: Request, res: Response, next: Next): void => {
             const id = req.params.id;

--- a/src/controllers/mixins.ts
+++ b/src/controllers/mixins.ts
@@ -3,7 +3,7 @@ import url from "url";
 import _ from "lodash/fp";
 import { Document, Model } from "mongoose";
 import { Next, Request, Response } from "restify";
-import { BadRequestError, NotFoundError } from "restify-errors";
+import { BadRequestError, NotFoundError, ForbiddenError } from "restify-errors";
 
 export interface DetailOptions {
     populate?: string[];
@@ -21,18 +21,48 @@ export interface QueryOptions {
 export const CRUDMixin = (superclass: any) => class extends superclass {
     protected model: Model<Document>;
 
+    protected namespaceAllowed(req: Request, namespace?: string | null): boolean {
+        const allowedNamespaces = req.params.allowedNamespaces || [];
+        if (allowedNamespaces.includes("all")) return true;
+        else if (allowedNamespaces.includes(namespace)) return true;
+        else return false;
+    }
+    
+    protected ensureNamespaceAuthorizedForPatch(
+        req: Request,
+        next: Next,
+        id: string,
+        cb: () => void,
+    ): void {
+        this.model.findById(id, (err:any, doc:any) => {
+            if (err) {
+                if (err.name === "DocumentNotFoundError") {
+                    return next(new NotFoundError(`${id} does not exist`));
+                }
+                return next(err);
+            }
+            const namespace = doc.get("namespace") || undefined;
+            if (namespace && !this.namespaceAllowed(req, namespace)) {
+                return next(new ForbiddenError("Insufficient namespace permissions"));
+            }
+            cb();
+        });
+    }
+
     public deactivate(): (req: Request, res: Response, next: Next) => void {
         return (req: Request, res: Response, next: Next) => {
-            this.model.findByIdAndUpdate(req.params.id, { active: false }, (err:Error) => {
-                if (err) {
-                    if (err.name === "DocumentNotFoundError") {
-                        return next(new NotFoundError(`${req.params.id} does not exist`));
-                    } else {
-                        return next(err);
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                this.model.findByIdAndUpdate(req.params.id, { active: false }, (err:Error) => {
+                    if (err) {
+                        if (err.name === "DocumentNotFoundError") {
+                            return next(new NotFoundError(`${req.params.id} does not exist`));
+                        } else {
+                            return next(err);
+                        }
                     }
-                }
-                res.status(204);
-                res.end();
+                    res.status(204);
+                    res.end();
+                });
             });
         };
     }
@@ -79,6 +109,12 @@ export const CRUDMixin = (superclass: any) => class extends superclass {
                 body = Array.of(body);
             }
             const documents = _.map((raw: object) => new this.model(raw), body);
+            for (const document of documents) {
+                const namespace = document.get("namespace") || undefined;
+                if (namespace && !this.namespaceAllowed(req, namespace)) {
+                    return next(new ForbiddenError("Insufficient namespace permissions"));
+                }
+            }
             Promise.all(_.map((doc: Document) => doc.validate(), documents))
                 .then(() => this.beforeInsert(documents))
                 .then((documents) => {
@@ -194,6 +230,7 @@ export const CRUDMixin = (superclass: any) => class extends superclass {
 export const DecidableMixin = (superclass: any) => class extends superclass {
     protected model: Model<Document>;
 
+    // TODO
     public appendDecision(): (req: Request, res: Response, next: Next) => void {
         return (req: Request, res: Response, next: Next): void => {
             const id = req.params.id;
@@ -202,18 +239,20 @@ export const DecidableMixin = (superclass: any) => class extends superclass {
             const update = { $push: { decisions: decision } };
             const options = { runValidators: true };
 
-            this.model.findByIdAndUpdate(id, update, options, (err:Error, old:any) => {
-                if (err) {
-                    if (err.name === "DocumentNotFoundError") {
-                        return next(new NotFoundError(`${req.params.id} does not exist`));
-                    } else if (err.name === "ValidationError") {
-                        return next(new BadRequestError(err.message));
-                    } else {
-                        return next(err);
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                this.model.findByIdAndUpdate(id, update, options, (err:Error, old:any) => {
+                    if (err) {
+                        if (err.name === "DocumentNotFoundError") {
+                            return next(new NotFoundError(`${req.params.id} does not exist`));
+                        } else if (err.name === "ValidationError") {
+                            return next(new BadRequestError(err.message));
+                        } else {
+                            return next(err);
+                        }
                     }
-                }
-                res.json(old);
-                res.end();
+                    res.json(old);
+                    res.end();
+                });
             });
         };
     }
@@ -225,15 +264,17 @@ export const DecidableMixin = (superclass: any) => class extends superclass {
 
             const query = { "_id": objId, "decisions._id": decisionId };
             const update = { $set: { "decisions.$.active": false } };
-            try {
-                this.model.findOneAndUpdate(query, update);
-                res.status(204);
-                res.end();
-                
-            }   catch(err) {
-                res.status(500);
-                return next(err);
-            }
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                try {
+                    this.model.findOneAndUpdate(query, update);
+                    res.status(204);
+                    res.end();
+                    
+                }   catch(err) {
+                    res.status(500);
+                    return next(err);
+                }
+            });
         };
     }
 };

--- a/src/controllers/point.ts
+++ b/src/controllers/point.ts
@@ -26,16 +26,18 @@ export default class PointController extends mix(Controller).with(CRUDMixin, Dec
 
             const update: { [key: string]: any } = { agents_status: req.body.agents_status };
 
-            this.model.findByIdAndUpdate(req.params.id, update, (err:any, old:any) => {
-                if (err) {
-                    if (err.name === "DocumentNotFoundError") {
-                        return next(new NotFoundError(`${req.params.id} does not exist`));
-                    } else {
-                        return next(err);
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                this.model.findByIdAndUpdate(req.params.id, update, (err:any, old:any) => {
+                    if (err) {
+                        if (err.name === "DocumentNotFoundError") {
+                            return next(new NotFoundError(`${req.params.id} does not exist`));
+                        } else {
+                            return next(err);
+                        }
                     }
-                }
-                res.json(old);
-                res.end();
+                    res.json(old);
+                    res.end();
+                });
             });
         };
     }

--- a/src/controllers/task.ts
+++ b/src/controllers/task.ts
@@ -7,7 +7,6 @@ import Controller from "./controller";
 import { CRUDMixin, DetailOptions, QueryOptions } from "./mixins";
 import auth0 from '../lib/auth0';
 
-
 export interface TaskControllerOptions {
     detail?: DetailOptions;
     query?: QueryOptions;
@@ -33,16 +32,18 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
                 update.closed = Date.now();
             }
 
-            this.model.findByIdAndUpdate(req.params.id, update, (err:any, old:any) => {
-                if (err) {
-                    if (err.name === "DocumentNotFoundError") {
-                        return next(new NotFoundError(`${req.params.id} does not exist`));
-                    } else {
-                        return next(err);
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                this.model.findByIdAndUpdate(req.params.id, update, (err:any, old:any) => {
+                    if (err) {
+                        if (err.name === "DocumentNotFoundError") {
+                            return next(new NotFoundError(`${req.params.id} does not exist`));
+                        } else {
+                            return next(err);
+                        }
                     }
-                }
-                res.json(old);
-                res.end();
+                    res.json(old);
+                    res.end();
+                });
             });
         };
     }
@@ -56,16 +57,18 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
 
             const update: { [key: string]: any } = { priority: req.body.priority };
 
-            this.model.findByIdAndUpdate(req.params.id, update, (err:any, old:any) => {
-                if (err) {
-                    if (err.name === "DocumentNotFoundError") {
-                        return next(new NotFoundError(`${req.params.id} does not exist`));
-                    } else {
-                        return next(err);
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                this.model.findByIdAndUpdate(req.params.id, update, (err:any, old:any) => {
+                    if (err) {
+                        if (err.name === "DocumentNotFoundError") {
+                            return next(new NotFoundError(`${req.params.id} does not exist`));
+                        } else {
+                            return next(err);
+                        }
                     }
-                }
-                res.json(old);
-                res.end();
+                    res.json(old);
+                    res.end();
+                });
             });
         };
     }
@@ -79,16 +82,18 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
 
             const update: { [key: string]: any } = { instructions: req.body.instructions };
 
-            this.model.findByIdAndUpdate(req.params.id, update, (err:any, old:any) => {
-                if (err) {
-                    if (err.name === "DocumentNotFoundError") {
-                        return next(new NotFoundError(`${req.params.id} does not exist`));
-                    } else {
-                        return next(err);
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                this.model.findByIdAndUpdate(req.params.id, update, (err:any, old:any) => {
+                    if (err) {
+                        if (err.name === "DocumentNotFoundError") {
+                            return next(new NotFoundError(`${req.params.id} does not exist`));
+                        } else {
+                            return next(err);
+                        }
                     }
-                }
-                res.json(old);
-                res.end();
+                    res.json(old);
+                    res.end();
+                });
             });
         }
     }
@@ -100,16 +105,18 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
                 return next(new BadRequestError("duration must be a number >= 0"));
             }
             const update = { $inc: {duration: req.body.duration}}
-            this.model.findByIdAndUpdate(req.params.id, update, (err:any, old:any) => {
-                if (err) {
-                    if (err.name === "DocumentNotFoundError") {
-                        return next(new NotFoundError(`${req.params.id} does not exist`));
-                    } else {
-                        return next(err);
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                this.model.findByIdAndUpdate(req.params.id, update, (err:any, old:any) => {
+                    if (err) {
+                        if (err.name === "DocumentNotFoundError") {
+                            return next(new NotFoundError(`${req.params.id} does not exist`));
+                        } else {
+                            return next(err);
+                        }
                     }
-                }
-                res.json(old);
-                res.end();
+                    res.json(old);
+                    res.end();
+                });
             });
         };
     }
@@ -122,18 +129,20 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
             const update = { $push: { points: point } };
             const options = { runValidators: true };
 
-            this.model.findByIdAndUpdate(id, update, options, (err:any, old:any) => {
-                if (err) {
-                    if (err.name === "DocumentNotFoundError") {
-                        return next(new NotFoundError(`${req.params.id} does not exist`));
-                    } else if (err.name === "ValidationError") {
-                        return next(new BadRequestError(err.message));
-                    } else {
-                        return next(err);
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                this.model.findByIdAndUpdate(id, update, options, (err:any, old:any) => {
+                    if (err) {
+                        if (err.name === "DocumentNotFoundError") {
+                            return next(new NotFoundError(`${req.params.id} does not exist`));
+                        } else if (err.name === "ValidationError") {
+                            return next(new BadRequestError(err.message));
+                        } else {
+                            return next(err);
+                        }
                     }
-                }
-                res.json(old);
-                res.end();
+                    res.json(old);
+                    res.end();
+                });
             });
         };
     }
@@ -146,19 +155,21 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
 
             const query = { "_id": objId, "points._id": pointId };
             const update = { $set: { "points.$.active": false } };
-            try {
-                this.model.findOneAndUpdate(query, update);
-                res.status(204);
-                res.end();
-                
-            }   catch(err) {
-                res.status(500);
-                if (err.name === "DocumentNotFoundError") {
-                    return next(new NotFoundError(`${req.params.id} does not exist`));
-                } else {
-                    return next(err);
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                try {
+                    this.model.findOneAndUpdate(query, update);
+                    res.status(204);
+                    res.end();
+                    
+                }   catch(err) {
+                    res.status(500);
+                    if (err.name === "DocumentNotFoundError") {
+                        return next(new NotFoundError(`${req.params.id} does not exist`));
+                    } else {
+                        return next(err);
+                    }
                 }
-            }
+            });
         };
     }
     
@@ -171,18 +182,20 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
                 return next(new BadRequestError("metadata must be a plain object"));
             }
             const update: { [key: string]: any } = { metadata: req.body.metadata };
-            this.model.findByIdAndUpdate(id, update, (err:any, old:any) => {
-                if (err) {
-                    if (err.name === "DocumentNotFoundError") {
-                        return next(new NotFoundError(`${req.params.id} does not exist`));
-                    } else if (err.name === "ValidationError") {
-                        return next(new BadRequestError(err.message));
-                    } else {
-                        return next(err);
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                this.model.findByIdAndUpdate(id, update, (err:any, old:any) => {
+                    if (err) {
+                        if (err.name === "DocumentNotFoundError") {
+                            return next(new NotFoundError(`${req.params.id} does not exist`));
+                        } else if (err.name === "ValidationError") {
+                            return next(new BadRequestError(err.message));
+                        } else {
+                            return next(err);
+                        }
                     }
-                }
-                res.json(old);
-                res.end();
+                    res.json(old);
+                    res.end();
+                });
             });
         };
     }
@@ -196,18 +209,20 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
                 return next(new BadRequestError("state must be a plain object"));
             }
             const update: { [key: string]: any } = { ng_state: req.body.ng_state };
-            this.model.findByIdAndUpdate(id, update, (err:any, old:any) => {
-                if (err) {
-                    if (err.name === "DocumentNotFoundError") {
-                        return next(new NotFoundError(`${req.params.id} does not exist`));
-                    } else if (err.name === "ValidationError") {
-                        return next(new BadRequestError(err.message));
-                    } else {
-                        return next(err);
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                this.model.findByIdAndUpdate(id, update, (err:any, old:any) => {
+                    if (err) {
+                        if (err.name === "DocumentNotFoundError") {
+                            return next(new NotFoundError(`${req.params.id} does not exist`));
+                        } else if (err.name === "ValidationError") {
+                            return next(new BadRequestError(err.message));
+                        } else {
+                            return next(err);
+                        }
                     }
-                }
-                res.json(old);
-                res.end();
+                    res.json(old);
+                    res.end();
+                });
             });
         };
     }
@@ -220,6 +235,7 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
                 return next(new BadRequestError("state must be a plain object"));
             }
             const update: { [key: string]: any } = { namespace: req.body.namespace };
+            // TODO
             this.model.findByIdAndUpdate(id, update, (err:any, old:any) => {
                 if (err) {
                     if (err.name === "DocumentNotFoundError") {
@@ -244,18 +260,20 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
                 return next(new BadRequestError("assignee must be a plain object"));
             }
             const update: { [key: string]: any } = { assignee: req.body.assignee };
-            this.model.findByIdAndUpdate(id, update, (err:any, old:any) => {
-                if (err) {
-                    if (err.name === "DocumentNotFoundError") {
-                        return next(new NotFoundError(`${req.params.id} does not exist`));
-                    } else if (err.name === "ValidationError") {
-                        return next(new BadRequestError(err.message));
-                    } else {
-                        return next(err);
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                this.model.findByIdAndUpdate(id, update, (err:any, old:any) => {
+                    if (err) {
+                        if (err.name === "DocumentNotFoundError") {
+                            return next(new NotFoundError(`${req.params.id} does not exist`));
+                        } else if (err.name === "ValidationError") {
+                            return next(new BadRequestError(err.message));
+                        } else {
+                            return next(err);
+                        }
                     }
-                }
-                res.json(old);
-                res.end();
+                    res.json(old);
+                    res.end();
+                });
             });
         };
     }
@@ -268,18 +286,20 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
                 return next(new BadRequestError("Seg ID must be a plain object"));
             }
             const update: { [key: string]: any } = { seg_id: req.body.seg_id };
-            this.model.findByIdAndUpdate(id, update, (err:any, old:any) => {
-                if (err) {
-                    if (err.name === "DocumentNotFoundError") {
-                        return next(new NotFoundError(`${req.params.id} does not exist`));
-                    } else if (err.name === "ValidationError") {
-                        return next(new BadRequestError(err.message));
-                    } else {
-                        return next(err);
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                this.model.findByIdAndUpdate(id, update, (err:any, old:any) => {
+                    if (err) {
+                        if (err.name === "DocumentNotFoundError") {
+                            return next(new NotFoundError(`${req.params.id} does not exist`));
+                        } else if (err.name === "ValidationError") {
+                            return next(new BadRequestError(err.message));
+                        } else {
+                            return next(err);
+                        }
                     }
-                }
-                res.json(old);
-                res.end();
+                    res.json(old);
+                    res.end();
+                });
             });
         };
     }
@@ -291,18 +311,20 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
                 return next(new BadRequestError("tags must be a plain object"));
             }
             const update: { [key: string]: any } = { tags: req.body.tags };
-            this.model.findByIdAndUpdate(id, update, (err:any, old:any) => {
-                if (err) {
-                    if (err.name === "DocumentNotFoundError") {
-                        return next(new NotFoundError(`${req.params.id} does not exist`));
-                    } else if (err.name === "ValidationError") {
-                        return next(new BadRequestError(err.message));
-                    } else {
-                        return next(err);
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                this.model.findByIdAndUpdate(id, update, (err:any, old:any) => {
+                    if (err) {
+                        if (err.name === "DocumentNotFoundError") {
+                            return next(new NotFoundError(`${req.params.id} does not exist`));
+                        } else if (err.name === "ValidationError") {
+                            return next(new BadRequestError(err.message));
+                        } else {
+                            return next(err);
+                        }
                     }
-                }
-                res.json(old);
-                res.end();
+                    res.json(old);
+                    res.end();
+                });
             });
         };
     }
@@ -312,18 +334,20 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
             const id = req.params.id;
             
             const update: { [key: string]: any } = { active: true };
-            this.model.findByIdAndUpdate(id, update, (err:any, old:any) => {
-                if (err) {
-                    if (err.name === "DocumentNotFoundError") {
-                        return next(new NotFoundError(`${req.params.id} does not exist`));
-                    } else if (err.name === "ValidationError") {
-                        return next(new BadRequestError(err.message));
-                    } else {
-                        return next(err);
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                this.model.findByIdAndUpdate(id, update, (err:any, old:any) => {
+                    if (err) {
+                        if (err.name === "DocumentNotFoundError") {
+                            return next(new NotFoundError(`${req.params.id} does not exist`));
+                        } else if (err.name === "ValidationError") {
+                            return next(new BadRequestError(err.message));
+                        } else {
+                            return next(err);
+                        }
                     }
-                }
-                res.json(old);
-                res.end();
+                    res.json(old);
+                    res.end();
+                });
             });
         };
     }

--- a/src/controllers/task.ts
+++ b/src/controllers/task.ts
@@ -1,7 +1,7 @@
 import _ from "lodash/fp";
 import { Document, Model } from "mongoose";
 import { Next, Request, Response, Server } from "restify";
-import { BadRequestError, NotFoundError } from "restify-errors";
+import { BadRequestError, NotFoundError, ForbiddenError } from "restify-errors";
 import mix from "../utils/mix";
 import Controller from "./controller";
 import { CRUDMixin, DetailOptions, QueryOptions } from "./mixins";
@@ -235,19 +235,23 @@ export default class TaskController extends mix(Controller).with(CRUDMixin) {
                 return next(new BadRequestError("state must be a plain object"));
             }
             const update: { [key: string]: any } = { namespace: req.body.namespace };
-            // TODO
-            this.model.findByIdAndUpdate(id, update, (err:any, old:any) => {
-                if (err) {
-                    if (err.name === "DocumentNotFoundError") {
-                        return next(new NotFoundError(`${req.params.id} does not exist`));
-                    } else if (err.name === "ValidationError") {
-                        return next(new BadRequestError(err.message));
-                    } else {
-                        return next(err);
+            if (!this.namespaceAllowed(req, req.body.namespace)) {
+                return next(new ForbiddenError("Insufficient namespace permissions"));
+            }
+            this.ensureNamespaceAuthorizedForPatch(req, next, req.params.id, () => {
+                this.model.findByIdAndUpdate(id, update, (err:any, old:any) => {
+                    if (err) {
+                        if (err.name === "DocumentNotFoundError") {
+                            return next(new NotFoundError(`${req.params.id} does not exist`));
+                        } else if (err.name === "ValidationError") {
+                            return next(new BadRequestError(err.message));
+                        } else {
+                            return next(err);
+                        }
                     }
-                }
-                res.json(old);
-                res.end();
+                    res.json(old);
+                    res.end();
+                });
             });
         };
     }

--- a/src/lib/auth0.ts
+++ b/src/lib/auth0.ts
@@ -1,14 +1,21 @@
 import rjwt from "./restify-jwt";
 import jwksRsa from "jwks-rsa";
 
+const jwks = jwksRsa({
+  cache: true,
+  rateLimit: true,
+  jwksUri: `https://${process.env.AUTH0_DOMAIN}/.well-known/jwks.json`,
+});
+
 const tokenGuard = rjwt({
   // Fetch the signing key based on the KID in the header and
   // the singing keys provided by the JWKS endpoint.
-  secret: jwksRsa.expressJwtSecret({
-    cache: true,
-    rateLimit: true,
-    jwksUri: `https://${process.env.AUTH0_DOMAIN}/.well-known/jwks.json`
-  }),
+  secret: (req: any, header: any, _payload: any, cb: any) => {
+    jwks.getSigningKey(header.kid, (err: any, key: any) => {
+      if (err) return cb(err);
+      cb(null, key.getPublicKey());
+    });
+  },
 
   // Validate the audience and the issuer.
   audience: process.env.AUTH0_AUDIENCE,

--- a/src/lib/restify-jwt.ts
+++ b/src/lib/restify-jwt.ts
@@ -1,6 +1,7 @@
 import jwt from "jsonwebtoken";
 import unless from "express-unless";
 import async from "async";
+import { BadRequestError } from "restify-errors";
 
 // import InvalidCredentialsError from "restify-errors/InvalidCredentialsError";
 // import UnauthorizedError from "restify-errors/UnauthorizedError";
@@ -22,7 +23,8 @@ function wrapStaticSecretInCallback(secret:any) {
 }
 
 interface JwtPayload {
-  permissions: string,
+  permissions: string[],
+  allowed_namespaces: string[],
   gty: string
 }
 
@@ -120,7 +122,21 @@ export default function rjwt(options:any) {
     // THIS WAS NOT WRITTEN BY A PROFESSIONAL BACKEND DEV - juryrigged from express code
     const payloadObj = idToken.payload as JwtPayload;
     if (checkScopes) {
-      console.log(scope);
+
+      // Parse namespace from request to determine if user is authorized
+      // Hannah note: this namespace clause will work for queries which include sieve=namespace. need to figure out best way to do this for other kinds of queries...
+      let namespace = "";
+      if (req.query.q) {
+          try {
+              const q = JSON.parse(req.query.q);
+              namespace = q.namespace;
+          } catch (err) {
+              return next(new BadRequestError("query is not a valid JSON object"));
+          }
+      }
+      const allowedNamespaces = payloadObj.allowed_namespaces;
+      const hasAllowedNamespace = allowedNamespaces.includes(namespace) || allowedNamespaces.includes("all");
+
       const hasExpectedScopes = payloadObj.permissions.includes(scope);
       // something like this can be done to implement checking of multiple scopes
       // const hasExpectedScopes = expectedScopes.every(s => idToken.payload.permissions.includes(s));
@@ -133,7 +149,7 @@ export default function rjwt(options:any) {
           console.log("Passed with client-credentials grant type")
         }
       }
-      if (!hasExpectedScopes && !client_credentials_flag) {
+      if ((!hasExpectedScopes || !hasAllowedNamespace) && !client_credentials_flag) {
         console.log("Token valid but insufficient permissions")
         return res.send(
           new Error(

--- a/src/lib/restify-jwt.ts
+++ b/src/lib/restify-jwt.ts
@@ -1,7 +1,6 @@
 import jwt from "jsonwebtoken";
 import unless from "express-unless";
 import async from "async";
-import { BadRequestError } from "restify-errors";
 
 // import InvalidCredentialsError from "restify-errors/InvalidCredentialsError";
 // import UnauthorizedError from "restify-errors/UnauthorizedError";
@@ -123,19 +122,8 @@ export default function rjwt(options:any) {
     const payloadObj = idToken.payload as JwtPayload;
     if (checkScopes) {
 
-      // Parse namespace from request to determine if user is authorized
-      // Hannah note: this namespace clause will work for queries which include sieve=namespace. need to figure out best way to do this for other kinds of queries...
-      let namespace = "";
-      if (req.query.q) {
-          try {
-              const q = JSON.parse(req.query.q);
-              namespace = q.namespace;
-          } catch (err) {
-              return next(new BadRequestError("query is not a valid JSON object"));
-          }
-      }
       const allowedNamespaces = payloadObj.allowed_namespaces;
-      const hasAllowedNamespace = allowedNamespaces.includes(namespace) || allowedNamespaces.includes("all");
+      req.params.allowedNamespaces = allowedNamespaces;
 
       const hasExpectedScopes = payloadObj.permissions.includes(scope);
       // something like this can be done to implement checking of multiple scopes
@@ -149,7 +137,7 @@ export default function rjwt(options:any) {
           console.log("Passed with client-credentials grant type")
         }
       }
-      if ((!hasExpectedScopes || !hasAllowedNamespace) && !client_credentials_flag) {
+      if (!hasExpectedScopes && !client_credentials_flag) {
         console.log("Token valid but insufficient permissions")
         return res.send(
           new Error(
@@ -164,7 +152,7 @@ export default function rjwt(options:any) {
     console.log("Token valid")
     async.parallel(
       [
-        function (callback) {
+        function (callback:any) {
           const arity = secretCallback.length;
           if (arity === 4) {
             secretCallback(
@@ -178,11 +166,11 @@ export default function rjwt(options:any) {
             secretCallback(req, idToken.payload, callback);
           }
         },
-        function (callback) {
+        function (callback:any) {
           isRevokedCallback(req, idToken.payload, callback);
         }
       ],
-      function (err, results:any) {
+      function (err:any, results:any) {
         if (err) {
           return res.send(err);
         }


### PR DESCRIPTION
**Changes**
* In the Auth0 dashboard, the new app_metadata field `allowed_namespaces` is added to the token via a post-login trigger.
  * This field is a list. If "all" appears in the list, then the code changes in this PR will grant the user write access to all namespaces. Otherwise, the user is granted access only to the namespaces in the list.
* In the Auth0 guard code, this field is propagated to the request params.
* All post, patch, and del requests have an additional wrapper function that checks whether the namespace of the requested action appears in the `allowed_namespaces`.
  * Post requests check the namespace of each document to be inserted
  * Patch and del requests query the document to be edited/deactivated and check its namespace before allowing the action
  * Patch namespace checks both the original and requested namespaces
  
Please test locally yourself before merging, as this would not be fun to go back and debug later if there are any bugs! I can send a script and pointers if helpful.